### PR TITLE
EO-733

### DIFF
--- a/tvApp/src/main/java/band/effective/office/tv/screen/eventStory/EventStoryViewModel.kt
+++ b/tvApp/src/main/java/band/effective/office/tv/screen/eventStory/EventStoryViewModel.kt
@@ -117,8 +117,9 @@ class EventStoryViewModel @Inject constructor(
                 when (events) {
                     is Either.Success -> {
                         val teammates = events.data.filterIsInstance<EmployeeInfoEntity>()
+                        val employeeStories = teammates.processEmployeeInfo()
                         updateStateAsSuccessfulFetch(
-                            teammates.processEmployeeInfo() +
+                            employeeStories +
                                     setDuolingoDataToStoryModel(
                                         events.data.filterIsInstance<DuolingoUser>()
                                     ) +

--- a/tvApp/src/main/java/band/effective/office/tv/screen/leaderIdEvents/LeaderIdEventsViewModel.kt
+++ b/tvApp/src/main/java/band/effective/office/tv/screen/leaderIdEvents/LeaderIdEventsViewModel.kt
@@ -32,7 +32,7 @@ class LeaderIdEventsViewModel @Inject constructor(
     val finish = GregorianCalendar()
 
     init {
-        finish.set(Calendar.MONTH, GregorianCalendar().get(Calendar.MONTH) + 1)
+        finish.add(Calendar.DAY_OF_MONTH, 14)
         load()
         timer.init(
             scope = viewModelScope, callbackToEnd = {

--- a/tvApp/src/main/java/band/effective/office/tv/screen/photo/BestPhotoScreen.kt
+++ b/tvApp/src/main/java/band/effective/office/tv/screen/photo/BestPhotoScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
-import androidx.compose.ui.input.key.*
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.tv.foundation.lazy.list.TvLazyListState
 import androidx.tv.foundation.lazy.list.rememberTvLazyListState
@@ -83,6 +82,11 @@ fun BestPhotoScreen(viewModel: PhotoViewModel = hiltViewModel()) {
                     )
                 },
                 onClickPlayButton = { viewModel.sendEvent(BestPhotoEvent.OnClickPlayButton) },
+                onError = { num ->
+                    viewModel.sendEvent(
+                        BestPhotoEvent.OnClickNextItem(num)
+                    )
+                },
                 uiState = uiState,
                 playButton = playButton,
                 contentFocus = contentFocus,
@@ -98,6 +102,7 @@ private fun PhotoContent(
     onClickPreviousItemButton: (Int) -> Unit,
     onClickNextItemButton: (Int) -> Unit,
     onClickPlayButton: () -> Unit,
+    onError: (Int) -> Unit,
     uiState: BestPhotoState,
     lazyListState: TvLazyListState,
     contentFocus: FocusRequester,
@@ -124,6 +129,7 @@ private fun PhotoContent(
                         down = playButton
                     }
                     .focusable(),
+                onError = onError,
                 unsafeOkHttpClient = unsafeOkHttpClient
             )
         },

--- a/tvApp/src/main/java/band/effective/office/tv/screen/photo/components/PhotoSlideShow.kt
+++ b/tvApp/src/main/java/band/effective/office/tv/screen/photo/components/PhotoSlideShow.kt
@@ -6,7 +6,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.tv.foundation.lazy.list.TvLazyListState
 import androidx.tv.foundation.lazy.list.TvLazyRow
-import androidx.tv.foundation.lazy.list.items
+import androidx.tv.foundation.lazy.list.itemsIndexed
 import androidx.tv.foundation.lazy.list.rememberTvLazyListState
 import band.effective.office.tv.screen.photo.model.Photo
 import okhttp3.OkHttpClient
@@ -17,6 +17,7 @@ fun PhotoSlideShow(
     lazyListState: TvLazyListState = rememberTvLazyListState(),
     modifier: Modifier = Modifier,
     modifierForFocus: Modifier = Modifier,
+    onError: (Int) -> Unit,
     unsafeOkHttpClient: OkHttpClient
 ) {
     TvLazyRow(
@@ -25,11 +26,16 @@ fun PhotoSlideShow(
             .fillMaxSize()
             .focusable()
     ) {
-        items(photos) { photo ->
+        itemsIndexed(photos) { photoIdx, photo ->
             PhotoUIItem(
                 image = photo,
                 modifier = modifierForFocus
                     .fillMaxSize(),
+                onError = {
+                    if (lazyListState.firstVisibleItemIndex == photoIdx) {
+                        onError(photoIdx)
+                    }
+                },
                 okHttpClient = unsafeOkHttpClient
             )
         }

--- a/tvApp/src/main/java/band/effective/office/tv/screen/photo/components/PhotoUI.kt
+++ b/tvApp/src/main/java/band/effective/office/tv/screen/photo/components/PhotoUI.kt
@@ -3,17 +3,13 @@ package band.effective.office.tv.screen.photo.components
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import band.effective.office.tv.R
 import band.effective.office.tv.screen.load.LoadScreen
 import band.effective.office.tv.screen.photo.model.Photo
@@ -23,12 +19,18 @@ import okhttp3.OkHttpClient
 
 
 @Composable
-fun PhotoUIItem(image: Photo, modifier: Modifier = Modifier, okHttpClient: OkHttpClient) {
+fun PhotoUIItem(
+    image: Photo,
+    modifier: Modifier = Modifier,
+    onError: () -> Unit,
+    okHttpClient: OkHttpClient
+) {
+    val context = LocalContext.current
 
     val photoWith = LocalConfiguration.current.screenWidthDp.dp
     val photoHeight = LocalConfiguration.current.screenHeightDp.dp
 
-    val imageLoader = ImageLoader.Builder(LocalContext.current)
+    val imageLoader = ImageLoader.Builder(context)
         .okHttpClient(okHttpClient)
         .build()
 
@@ -47,13 +49,7 @@ fun PhotoUIItem(image: Photo, modifier: Modifier = Modifier, okHttpClient: OkHtt
             contentDescription = null,
             contentScale = ContentScale.Fit,
             error = {
-                Text(
-                    text = stringResource(id = R.string.error_show_photo),
-                    fontSize = 40.sp,
-                    color = Color.Red,
-                    textAlign = TextAlign.Center,
-                    modifier = Modifier.fillMaxSize()
-                )
+                onError()
             }
         )
     }

--- a/tvApp/src/main/res/values/strings.xml
+++ b/tvApp/src/main/res/values/strings.xml
@@ -29,7 +29,7 @@
     <string name="top_for_XP">"Tоп по XP"</string>
     <string name="top_for_days">"Топ по дням в ударном режиме"</string>
     <string name="duolingo_attribute_name">Профиль Duolingo</string>
-    <string name="error_show_photo">Мы пока не поддерживаем этот формат фото, позже все будет ок)</string>
+    <string name="error_show_photo">Произошла ошибка при загрузке следующего фото: %1$s</string>
     <string name="photo_title">Best Photo</string>
     <string name="autoplay_button_text">autoplay</string>
     <string name="autoplay_zero_select">Выберите минимум одну категорию</string>


### PR DESCRIPTION
**Изменение периода отображения мероприятий с Точки кипения

Задача:
- Сейчас на TV мероприятия с Точки кипения подтягиваются на месяц вперед, необходимо изменить это так, что мероприятия подтягивались на 2 недели.

Описание:
- В текущей реализации мероприятия с Точки кипения загружаются на месяц вперед. В этом PR изменено формирование дат, и теперь мероприятия подтягиваются только на ближайшие 2 недели.

Изменено формирование дат:
- Период мероприятий сокращен с 30 до 14 дней.

Новый запрос к API Leader-ID:
https://leader-id.ru/api/v4/events/search?paginationSize=100&dateFrom=2025-03-04&dateTo=2025-03-18&cityId=893&placeIds[]=3942

Результат:
- Проверено, что данные загружаются корректно и без ошибок.
- Новый запрос к API возвращает ожидаемые результаты с мероприятиями на 14 дней.**