### PR TITLE
tvApp: Fix event display issue caused by incomplete speaker data

### DIFF
--- a/tvApp/src/main/java/band/effective/office/tv/network/leader/models/eventInfo/Speaker.kt
+++ b/tvApp/src/main/java/band/effective/office/tv/network/leader/models/eventInfo/Speaker.kt
@@ -5,38 +5,38 @@ import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
 data class Speaker(
-    val completed: Boolean,
+    val completed: Boolean?,
     @Json(name = "completed_at")
     val completedAt: Any?,
     @Json(name = "control_passed")
     val controlPassed: Any?,
     @Json(name = "created_at")
-    val createdAt: String,
+    val createdAt: String?,
     @Json(name = "event_id")
-    val eventId: Int,
+    val eventId: Int?,
     val format: Any?,
-    val id: String,
-    val moderation: String,
+    val id: String?,
+    val moderation: String?,
     @Json(name = "number_participants")
     val numberParticipants: Any?,
     @Json(name = "quiz_answer_id")
     val quizAnswerId: Any?,
     @Json(name = "rejected_by")
     val rejectedBy: Any?,
-    val role: String,
+    val role: String?,
     @Json(name = "role_id")
-    val roleId: Int,
+    val roleId: Int?,
     @Json(name = "")
     val spaceId: Any?,
-    val status: Int,
+    val status: Int?,
     @Json(name = "team_id")
     val teamId: Any?,
     @Json(name = "updated_at")
     val updatedAt: Any?,
     val user: User,
     @Json(name = "user_id")
-    val userId: Int,
-    val visible: Boolean,
+    val userId: Int?,
+    val visible: Boolean?,
     @Json(name = "w_group_ids")
     val wGroupIds: Any?
 )


### PR DESCRIPTION
Проблема:
 В приложении tvApp при отображении мероприятия возникала ошибка, если у него был спикер с неполной информацией. Ошибка была связана с тем, что API могло присылать null-значения, которые не обрабатывались в коде.
Решение:
 Сделал поля модели Speaker nullable, чтобы избежать ошибок при отсутствии данных.
Результат:
 Теперь мероприятие корректно отображается даже при отсутствии части данных.
![photo_2025-03-08_13-02-38](https://github.com/user-attachments/assets/e8ac03fd-6409-42ad-a23a-99128a2b509e)
![photo_2025-03-08_13-02-40](https://github.com/user-attachments/assets/9313617f-2de8-4354-9631-52113f53a968)
![photo_2025-03-08_13-02-43](https://github.com/user-attachments/assets/6380c3d4-9ab1-4d23-9852-3359df525f95)

