### PR TITLE
tvApp/EO-763:  update Notion DB birthday field and fix status check

### DIFF
--- a/notion/src/main/kotlin/band/effective/office/workTogether/Teammate.kt
+++ b/notion/src/main/kotlin/band/effective/office/workTogether/Teammate.kt
@@ -15,5 +15,5 @@ data class Teammate(
     val photo: String,
     val status: String,
 ) {
-    fun isActive() = employment in setOf("Band", "Intern") && status == "Active"
+    fun isActive() = employment?.trim() in setOf("Band", "Intern") && status == "Active"
 }

--- a/notion/src/main/kotlin/band/effective/office/workTogether/WorkTogetherImpl.kt
+++ b/notion/src/main/kotlin/band/effective/office/workTogether/WorkTogetherImpl.kt
@@ -39,7 +39,7 @@ class WorkTogetherImpl(private val notionClient: NotionClient, private val notio
             positions = getStringFromProp("Position")?.split(" ") ?: listOf(),
             employment = getStringFromProp("Employment") ?: "Null employment",
             startDate = getDateFromProp("Start Date"),
-            nextBDay = getDateFromProp("Next B-DAY"),
+            nextBDay = getDateFromProp("Birthday (any year)"),
             workEmail = getStringFromProp("Effective Email"),
             personalEmail = getStringFromProp("Personal Email") ?: "",
             duolingo = getStringFromProp("Профиль Duolingo"),

--- a/tvApp/src/main/java/band/effective/office/tv/repository/duolingo/impl/DuolingoRepositoryImpl.kt
+++ b/tvApp/src/main/java/band/effective/office/tv/repository/duolingo/impl/DuolingoRepositoryImpl.kt
@@ -18,8 +18,8 @@ class DuolingoRepositoryImpl @Inject constructor(
         flow {
             val users = teammates.filter {
                 it.duolingo != null
-                        && it.employment == EmploymentType.Band.value
-                        && it.status == "Active"
+                        && it.employment.trim() == EmploymentType.Band.value
+                        && it.status.trim() == "Active"
             }
             var error = false
             val data = users.mapNotNull {


### PR DESCRIPTION
Обновление маппинга полей Notion
Изменено полt, используемое для получения дня рождения сотрудников. Вместо колонки “Next B-DAY” (ее необходимо будет удалить из notion) теперь используется колонка “Birthday (any year)”.

Фикс обработки поля Employment и Status
Добавлена обработка пробелов в начале и конце значения статуса. Теперь статусы вида (После перехода на новое пространство notion возвращаются данные с пробелом) " Active", " Intern" и " Band" автоматически триммируются, чтобы избежать ошибок фильтрации.