### PR TITLE
tvApp/EO-763: update Notion DB birthday field and fix status check

### DIFF
--- a/notion/src/main/kotlin/band/effective/office/workTogether/WorkTogetherImpl.kt
+++ b/notion/src/main/kotlin/band/effective/office/workTogether/WorkTogetherImpl.kt
@@ -37,14 +37,14 @@ class WorkTogetherImpl(private val notionClient: NotionClient, private val notio
             id = id,
             name = getStringFromProp("Name") ?: "Null name",
             positions = getStringFromProp("Position")?.split(" ") ?: listOf(),
-            employment = getStringFromProp("Employment") ?: "Null employment",
+            employment = getStringFromProp("Employment")?.trim()  ?: "Null employment",
             startDate = getDateFromProp("Start Date"),
-            nextBDay = getDateFromProp("Next B-DAY"),
+            nextBDay = getDateFromProp("Birthday (any year)"),
             workEmail = getStringFromProp("Effective Email"),
             personalEmail = getStringFromProp("Personal Email") ?: "",
             duolingo = getStringFromProp("Профиль Duolingo"),
             photo = getIconUrl() ?: "",
-            status = getStringFromProp("Status") ?: "Empty status"
+            status = getStringFromProp("Status")?.trim() ?: "Empty status"
         )
 
     private fun Page.getStringFromProp(propName: String) =


### PR DESCRIPTION
Обновление маппинга полей Notion
Изменено поле, используемое для получения дня рождения сотрудников. Вместо колонки “Next B-DAY” (ее необходимо будет удалить из notion) теперь используется колонка “Birthday (any year)”.

Фикс обработки поля Employment и Status
Добавлена обработка пробелов в начале и конце значения статуса. Теперь статусы вида (После перехода на новое пространство notion возвращаются данные с пробелом) " Active", " Intern" и " Band" автоматически триммируются, чтобы избежать ошибок фильтрации.