### PR TITLE
tvApp/EO-763: update Notion DB birthday field, fix status check and sorting stories employee list

### DIFF
--- a/notion/src/main/kotlin/band/effective/office/workTogether/Teammate.kt
+++ b/notion/src/main/kotlin/band/effective/office/workTogether/Teammate.kt
@@ -15,5 +15,7 @@ data class Teammate(
     val photo: String,
     val status: String,
 ) {
-    fun isActive() = employment in setOf("Band", "Intern") && status == "Active"
+    fun isActive() = (employment.contains("Band") == true
+            || employment.contains("Intern") == true)
+            && status == "Active"
 }

--- a/notion/src/main/kotlin/band/effective/office/workTogether/WorkTogetherImpl.kt
+++ b/notion/src/main/kotlin/band/effective/office/workTogether/WorkTogetherImpl.kt
@@ -37,14 +37,14 @@ class WorkTogetherImpl(private val notionClient: NotionClient, private val notio
             id = id,
             name = getStringFromProp("Name") ?: "Null name",
             positions = getStringFromProp("Position")?.split(" ") ?: listOf(),
-            employment = getStringFromProp("Employment") ?: "Null employment",
+            employment = getStringFromProp("Employment")?.trimStart() ?: "Null employment",
             startDate = getDateFromProp("Start Date"),
-            nextBDay = getDateFromProp("Next B-DAY"),
+            nextBDay = getDateFromProp("Birthday (any year)"),
             workEmail = getStringFromProp("Effective Email"),
             personalEmail = getStringFromProp("Personal Email") ?: "",
             duolingo = getStringFromProp("Профиль Duolingo"),
             photo = getIconUrl() ?: "",
-            status = getStringFromProp("Status") ?: "Empty status"
+            status = getStringFromProp("Status")?.trimStart() ?: "Empty status"
         )
 
     private fun Page.getStringFromProp(propName: String) =

--- a/tvApp/src/main/java/band/effective/office/tv/repository/duolingo/impl/DuolingoRepositoryImpl.kt
+++ b/tvApp/src/main/java/band/effective/office/tv/repository/duolingo/impl/DuolingoRepositoryImpl.kt
@@ -18,7 +18,7 @@ class DuolingoRepositoryImpl @Inject constructor(
         flow {
             val users = teammates.filter {
                 it.duolingo != null
-                        && it.employment == EmploymentType.Band.value
+                        && it.employment.contains(EmploymentType.Band.value) == true
                         && it.status == "Active"
             }
             var error = false

--- a/tvApp/src/main/java/band/effective/office/tv/screen/eventStory/EventStoryViewModel.kt
+++ b/tvApp/src/main/java/band/effective/office/tv/screen/eventStory/EventStoryViewModel.kt
@@ -158,16 +158,16 @@ class EventStoryViewModel @Inject constructor(
         SupernovaUserInfo(
             users = supernovaUsers
                 .toUi(employees)
-                .take(countUsersToShow)
                 .sortedByDescending { it.score }
+                .take(countUsersToShow)
         ) as StoryModel
 
     private fun setDuolingoDataToStoryModel(duolingoUsers: List<DuolingoUser>) =
         run {
             val userXpSort = DuolingoUserInfo(
                 users = duolingoUsers
-                    .take(countUsersToShow)
                     .sortedByDescending { it.totalXp }
+                    .take(countUsersToShow)
                     .toUI(),
                 keySort = KeySortDuolingoUser.Xp
             ) as StoryModel


### PR DESCRIPTION
Обновление маппинга полей Notion
Изменено поле, используемое для получения дня рождения сотрудников. Вместо колонки “Next B-DAY” (ее необходимо будет удалить из notion) теперь используется колонка “Birthday (any year)”.

Фикс обработки поля Employment и Status
Добавлена обработка пробелов в начале и конце значения статуса. Теперь статусы вида (После перехода на новое пространство notion возвращаются данные с пробелом) " Active", " Intern" и " Band" автоматически триммируются, чтобы избежать ошибок фильтрации. (Заново открыл ПР, т.к. не отражались пользователи с несколькими "должностями" и заметил недочет сортировки)

Исправление фильтрации списка сотрудника: Заменил проблему, что пользователи неправильно сортируются, по кол-ву опыта дуалинго, а также очкам сверхновой. Проблема заключалась в том, что сначала брались 10 сотрудников сверху списка, а только после этого сортировались. Исправил эту проблему, Все данны корректно отображаются и сортируются